### PR TITLE
EDGCSOFT-31 - Add item notes field to AccessionItem schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <properties>
     <java.version>11</java.version>
     <folio-spring-base-version>1.0.1</folio-spring-base-version>
-    <openapi-generator.version>5.0.1</openapi-generator.version>
+    <openapi-generator.version>5.3.0</openapi-generator.version>
     <mapstruct.version>1.4.1.Final</mapstruct.version>
     <edge-dematic.yaml.file>src/main/resources/swagger.api/edge-caiasoft.yaml</edge-dematic.yaml.file>
     <sonar.exclusions>src/main/java/org/folio/ed/domain/**</sonar.exclusions>

--- a/src/main/java/org/folio/ed/service/RemoteStorageService.java
+++ b/src/main/java/org/folio/ed/service/RemoteStorageService.java
@@ -32,7 +32,7 @@ public class RemoteStorageService {
   public ReturnItemResponse returnItemByBarcode(String itemBarcode, String remoteStorageConfigurationId, String xOkapiTenant, String xOkapiToken) {
     return remoteStorageClient.returnItemById(remoteStorageConfigurationId, new CheckInItem().itemBarcode(itemBarcode), xOkapiTenant, xOkapiToken);
   }
-  
+
   public ResponseEntity<String> checkInByHoldId(String requestId, String remoteStorageConfigurationId, String xOkapiTenant, String xOkapiToken) {
     return remoteStorageClient.checkInByHoldId(remoteStorageConfigurationId, new CheckInRequest(UUID.fromString(requestId)), xOkapiTenant, xOkapiToken);
   }

--- a/src/main/resources/swagger.api/schemas/accessionItem.json
+++ b/src/main/resources/swagger.api/schemas/accessionItem.json
@@ -91,6 +91,15 @@
     "permanentLocationId": {
       "description": "Permanent location id",
       "$ref": "uuid.json"
+    },
+    "notes": {
+      "description": "Accession item notes",
+      "type": "array",
+      "items": {
+        "description": "Item note",
+        "type": "object",
+        "$ref": "itemNote.json"
+      }
     }
   },
   "additionalProperties": false,

--- a/src/main/resources/swagger.api/schemas/itemNote.json
+++ b/src/main/resources/swagger.api/schemas/itemNote.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Accession queue note",
+  "properties": {
+    "noteType": {
+      "description": "Note type",
+      "type": "string"
+    },
+    "note": {
+      "description": "Accession queue note",
+      "type": "string"
+    },
+    "staffOnly": {
+      "description": "Staff only flag",
+      "type": "boolean"
+    }
+  },
+  "additionalProperties": false,
+  "required": []
+}

--- a/src/test/java/org/folio/ed/controller/AccessionControllerTest.java
+++ b/src/test/java/org/folio/ed/controller/AccessionControllerTest.java
@@ -6,11 +6,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 
-
 import java.util.Base64;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class AccessionControllerTest extends TestBase {
 
@@ -25,5 +26,7 @@ public class AccessionControllerTest extends TestBase {
     var accessionUrl = String.format(ACCESSION_URL, edgePort, ITEM_BARCODE, REMOTE_STORAGE_CONFIGURATION_ID, apikey);
     var response = get(accessionUrl, new HttpHeaders(), AccessionItem.class);
     assertThat(response.getStatusCode(), is(HttpStatus.OK));
+    assertFalse(response.getBody().getNotes().isEmpty());
+    assertThat(response.getBody().getNotes().get(0).getNote(), equalTo("test note"));
   }
 }

--- a/src/test/resources/mappings/remote-storage.json
+++ b/src/test/resources/mappings/remote-storage.json
@@ -16,7 +16,7 @@
       },
       "response": {
         "status": 200,
-        "body": "{\"id\":\"de17bad7-2a30-4f1c-bee5-f653ded15629\", \"itemBarcode\":\"1001\", \"permanentLocationId\": \"b9dc25a2-a7fb-48ad-8da5-8f68e35ba0af\",  \"callNumber\": \"PN6519.C8A170 1987\"}",
+        "body": "{\"id\":\"de17bad7-2a30-4f1c-bee5-f653ded15629\", \"itemBarcode\":\"1001\", \"permanentLocationId\": \"b9dc25a2-a7fb-48ad-8da5-8f68e35ba0af\",  \"callNumber\": \"PN6519.C8A170 1987\", \"notes\": [ { \"noteType\": \"General note\", \"note\": \"test note\", \"staffOnly\": false } ]}",
         "headers": {
           "Content-Type": "application/json"
         }


### PR DESCRIPTION
[EDGCSOFT-31](https://issues.folio.org/browse/EDGCSOFT-31) - Add item notes field to AccessionItem schema

## Purpose
AccessionItem schema should be extended with item notes field

## Approach
* Updated schema
* Updated unit test

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [ ] Were any API paths or methods changed, added or removed?
   - [ ] Were there any schema changes?
   - [ ] Did any of the interface versions change?
   - [ ] Were permissions changed, added, or removed?
   - [ ] Are there new interface dependencies?
   - [x] There are no breaking changes in this PR.

 If there are breaking changes, please **STOP** and consider the following:

 - What other modules will these changes impact?
 - Do JIRAs exist to update the impacted modules?
   - [ ] If not, please create them
   - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
   - [ ] Do they have all they appropriate links to blocked/related issues?
 - Are the JIRAs under active development?
   - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
 - Do PRs exist for these changes?
   - [ ] If so, have they been approved?

 Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

 While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
