### PR TITLE
Add TLS configuration details to README and update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,95 @@ Institutional users should be granted the following permissions in order to use 
 ### Configuration
 Please refer to the [Configuration](https://github.com/folio-org/edge-common/blob/master/README.md#configuration) section in the [edge-common](https://github.com/folio-org/edge-common/blob/master/README.md) documentation to see all available system properties and their default values.
 
+### TLS Configuration for HTTP Endpoints
+
+To configure Transport Layer Security (TLS) for HTTP endpoints in edge module, the following configuration parameters can be used. These parameters allow you to specify key and keystore details necessary for setting up TLS.
+
+#### Configuration Parameters
+
+1. **`spring.ssl.bundle.jks.web-server.key.password`**
+- **Description**: Specifies the password for the private key in the keystore.
+- **Example**: `spring.ssl.bundle.jks.web-server.key.password=SecretPassword`
+
+2. **`spring.ssl.bundle.jks.web-server.key.alias`**
+- **Description**: Specifies the alias of the key within the keystore.
+- **Example**: `spring.ssl.bundle.jks.web-server.key.alias=localhost`
+
+3. **`spring.ssl.bundle.jks.web-server.keystore.location`**
+- **Description**: Specifies the location of the keystore file in the local file system.
+- **Example**: `spring.ssl.bundle.jks.web-server.keystore.location=/some/secure/path/test.keystore.bcfks`
+
+4. **`spring.ssl.bundle.jks.web-server.keystore.password`**
+- **Description**: Specifies the password for the keystore.
+- **Example**: `spring.ssl.bundle.jks.web-server.keystore.password=SecretPassword`
+
+5. **`spring.ssl.bundle.jks.web-server.keystore.type`**
+- **Description**: Specifies the type of the keystore. Common types include `JKS`, `PKCS12`, and `BCFKS`.
+- **Example**: `spring.ssl.bundle.jks.web-server.keystore.type=BCFKS`
+
+6. **`server.ssl.bundle`**
+- **Description**: Specifies which SSL bundle to use for configuring the server. This parameter links to the defined SSL bundle, for example, `web-server`.
+- **Example**: `server.ssl.bundle=web-server`
+
+7. **`server.port`**
+- **Description**: Specifies the port on which the server will listen for HTTPS requests.
+- **Example**: `server.port=8443`
+
+#### Example Configuration
+
+To enable TLS for the edge module using the above parameters, you need to provide them as the environment variables. Below is an example configuration:
+
+```properties
+spring.ssl.bundle.jks.web-server.key.password=SecretPassword
+spring.ssl.bundle.jks.web-server.key.alias=localhost
+spring.ssl.bundle.jks.web-server.keystore.location=classpath:test/test.keystore.bcfks
+spring.ssl.bundle.jks.web-server.keystore.password=SecretPassword
+spring.ssl.bundle.jks.web-server.keystore.type=BCFKS
+
+server.ssl.bundle=web-server
+server.port=8443
+```
+### TLS Configuration for Feign HTTP Clients
+
+To configure Transport Layer Security (TLS) for HTTP clients created using Feign annotations in the edge module, you can use the following configuration parameters. These parameters allow you to specify trust store details necessary for setting up TLS for Feign clients.
+
+#### Configuration Parameters
+
+1. **`folio.client.okapiUrl`**
+- **Description**: Specifies the base URL for the Okapi service.
+- **Example**: `folio.client.okapiUrl=https://okapi:443`
+
+2. **`folio.client.tls.enabled`**
+- **Description**: Enables or disables TLS for the Feign clients.
+- **Example**: `folio.client.tls.enabled=true`
+
+3. **`folio.client.tls.trustStorePath`**
+- **Description**: Specifies the location of the trust store file.
+- **Example**: `folio.client.tls.trustStorePath=classpath:/some/secure/path/test.truststore.bcfks`
+
+4. **`folio.client.tls.trustStorePassword`**
+- **Description**: Specifies the password for the trust store.
+- **Example**: `folio.client.tls.trustStorePassword="SecretPassword"`
+
+5. **`folio.client.tls.trustStoreType`**
+- **Description**: Specifies the type of the trust store. Common types include `JKS`, `PKCS12`, and `BCFKS`.
+- **Example**: `folio.client.tls.trustStoreType=bcfks`
+
+#### Note
+The `trustStorePath`, `trustStorePassword`, and `trustStoreType` parameters can be omitted if the server provides a public certificate.
+
+#### Example Configuration
+
+To enable TLS for Feign HTTP clients using the above parameters, you need to provide them as the environment variables. Below is an example configuration:
+
+```properties
+folio.client.okapiUrl=https://okapi:443
+folio.client.tls.enabled=true
+folio.client.tls.trustStorePath=classpath:test/test.truststore.bcfks
+folio.client.tls.trustStorePassword=SecretPassword
+folio.client.tls.trustStoreType=bcfks
+```
+
 ### Issue tracker
 See project [EDGCSOFT](https://issues.folio.org/browse/EDGCSOFT)
 at the [FOLIO issue tracker](https://dev.folio.org/guidelines/issue-tracker).

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
 
     <edge-caiasoft.yaml.file>src/main/resources/swagger.api/edge-caiasoft.yaml</edge-caiasoft.yaml.file>
-    <sonar.exclusions>src/main/java/org/folio/ed/domain/**</sonar.exclusions>
+    <sonar.exclusions>src/main/java/org/folio/ed/domain/**, src/main/java/org/folio/ed/EdgeCaiaSoftApplication.java</sonar.exclusions>
     <bc-fips.version>1.0.2.5</bc-fips.version>
     <bcpkix-fips.version>1.0.7</bcpkix-fips.version>
     <bctls-fips.version>1.0.19</bctls-fips.version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <edge-common-spring.version>2.4.1</edge-common-spring.version>
+    <edge-common-spring.version>2.4.2</edge-common-spring.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <wiremock.version>3.4.2</wiremock.version>
     <awaitility.version>4.2.0</awaitility.version>
@@ -37,9 +37,27 @@
 
     <edge-caiasoft.yaml.file>src/main/resources/swagger.api/edge-caiasoft.yaml</edge-caiasoft.yaml.file>
     <sonar.exclusions>src/main/java/org/folio/ed/domain/**</sonar.exclusions>
+    <bc-fips.version>1.0.2.5</bc-fips.version>
+    <bcpkix-fips.version>1.0.7</bcpkix-fips.version>
+    <bctls-fips.version>1.0.19</bctls-fips.version>
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bc-fips</artifactId>
+      <version>${bc-fips.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-fips</artifactId>
+      <version>${bcpkix-fips.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bctls-fips</artifactId>
+      <version>${bctls-fips.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.folio</groupId>
@@ -49,6 +67,10 @@
         <exclusion>
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk18on</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/src/main/java/org/folio/ed/EdgeCaiaSoftApplication.java
+++ b/src/main/java/org/folio/ed/EdgeCaiaSoftApplication.java
@@ -1,5 +1,6 @@
 package org.folio.ed;
 
+import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -8,12 +9,15 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerA
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
+import java.security.Security;
+
 @SpringBootApplication
 @EnableFeignClients
 @EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class, DataSourceTransactionManagerAutoConfiguration.class,
   HibernateJpaAutoConfiguration.class})
 public class EdgeCaiaSoftApplication {
   public static void main(String[] args) {
+    Security.addProvider(new BouncyCastleFipsProvider());
     SpringApplication.run(EdgeCaiaSoftApplication.class, args);
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,6 @@
+# Dokapi_url is deprecated. Please use folio.client.okapiUrl instead
 Dokapi_url: http://localhost:9130
+# okapi_url is deprecated. Please use folio.client.okapiUrl instead
 okapi_url: ${Dokapi_url}
 Dsecure_store_props: src/main/resources/ephemeral.properties
 secure_store_props: ${Dsecure_store_props}
@@ -51,6 +53,13 @@ folio:
     password: ${SYSTEM_USER_PASSWORD}
   environment: ${ENV:folio}
   okapi-url: ${Dokapi_url:http://okapi:9130}
+  client:
+    okapiUrl: http://localhost:9130
+    tls:
+      enabled: false
+#      trustStorePath: ~/test/test.truststore.bcfks
+#      trustStorePassword: "SecretPassword"
+#      trustStoreType: BCFKS
 
 # configurations update timeframe (millis)
 configurations.update.timeframe: 3600000

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -28,6 +28,9 @@ logging:
         cache: OFF
 
 folio.tenant.validation.enabled: false
+folio.client.okapiUrl: http://localhost:3333
+folio.client.tls.enabled: false
+
 
 # disable scheduling
 app.scheduling.enable: false


### PR DESCRIPTION
This introduces Transport Layer Security (TLS) configuration details for both HTTP endpoints and Feign HTTP clients in the README file. It also includes necessary updates to the application's Java implementation, including addition of new security dependencies in pom.xml, and initiation of the BouncyCastleFipsProvider in the main application file. The edge-common-spring dependency version was updated as well, alongside some modifications in the application-test.yml file.
