### PR TITLE
Update edge-common-spring version and add provider check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <edge-common-spring.version>2.4.2</edge-common-spring.version>
+    <edge-common-spring.version>2.4.3</edge-common-spring.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <wiremock.version>3.4.2</wiremock.version>
     <awaitility.version>4.2.0</awaitility.version>

--- a/src/main/java/org/folio/ed/EdgeCaiaSoftApplication.java
+++ b/src/main/java/org/folio/ed/EdgeCaiaSoftApplication.java
@@ -11,13 +11,17 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 
 import java.security.Security;
 
+import static org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider.PROVIDER_NAME;
+
 @SpringBootApplication
 @EnableFeignClients
 @EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class, DataSourceTransactionManagerAutoConfiguration.class,
   HibernateJpaAutoConfiguration.class})
 public class EdgeCaiaSoftApplication {
   public static void main(String[] args) {
-    Security.addProvider(new BouncyCastleFipsProvider());
+    if (Security.getProvider(PROVIDER_NAME) == null) {
+      Security.addProvider(new BouncyCastleFipsProvider());
+    }
     SpringApplication.run(EdgeCaiaSoftApplication.class, args);
   }
 }


### PR DESCRIPTION
The edge-common-spring version in the pom.xml file has been updated from version 2.4.2 to 2.4.3. Additionally, a security provider check has been added to the EdgeCaiaSoftApplication.java file. This ensures that the BouncyCastleFipsProvider is only added if it is not already present, avoiding the potential for provider duplication exception.
