### PR TITLE
Replace BouncyCastleFipsProvider with folio-tls-utils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,26 +37,14 @@
 
     <edge-caiasoft.yaml.file>src/main/resources/swagger.api/edge-caiasoft.yaml</edge-caiasoft.yaml.file>
     <sonar.exclusions>src/main/java/org/folio/ed/domain/**, src/main/java/org/folio/ed/EdgeCaiaSoftApplication.java</sonar.exclusions>
-    <bc-fips.version>1.0.2.5</bc-fips.version>
-    <bcpkix-fips.version>1.0.7</bcpkix-fips.version>
-    <bctls-fips.version>1.0.19</bctls-fips.version>
+    <folio-tls-utils.version>1.5.0</folio-tls-utils.version>
   </properties>
 
   <dependencies>
     <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bc-fips</artifactId>
-      <version>${bc-fips.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-fips</artifactId>
-      <version>${bcpkix-fips.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bctls-fips</artifactId>
-      <version>${bctls-fips.version}</version>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-tls-utils</artifactId>
+      <version>${folio-tls-utils.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/folio/ed/EdgeCaiaSoftApplication.java
+++ b/src/main/java/org/folio/ed/EdgeCaiaSoftApplication.java
@@ -1,6 +1,6 @@
 package org.folio.ed;
 
-import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -9,19 +9,16 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerA
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
-import java.security.Security;
-
-import static org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider.PROVIDER_NAME;
+import static org.folio.common.utils.tls.FipsChecker.getFipsChecksResultString;
 
 @SpringBootApplication
 @EnableFeignClients
 @EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class, DataSourceTransactionManagerAutoConfiguration.class,
   HibernateJpaAutoConfiguration.class})
+@Log4j2
 public class EdgeCaiaSoftApplication {
   public static void main(String[] args) {
-    if (Security.getProvider(PROVIDER_NAME) == null) {
-      Security.addProvider(new BouncyCastleFipsProvider());
-    }
+    log.info(getFipsChecksResultString());
     SpringApplication.run(EdgeCaiaSoftApplication.class, args);
   }
 }


### PR DESCRIPTION
BouncyCastleFipsProvider dependencies have been removed from EdgeCaiaSoftApplication and the pom.xml file. In place of this, folio-tls-utils have been adde.
