### PR TITLE
EDGCSOFT-68: edge-common-spring 2.4.4, Spring Boot 3.2.6 fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.3</version>
+    <version>3.2.6</version>
     <relativePath />
   </parent>
 
@@ -23,7 +23,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <edge-common-spring.version>2.4.3</edge-common-spring.version>
+    <edge-common-spring.version>2.4.4</edge-common-spring.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <wiremock.version>3.4.2</wiremock.version>
     <awaitility.version>4.2.0</awaitility.version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGCSOFT-68

Upgrade edge-common-spring from 2.4.3 to 2.4.4.

Upgrade Spring Boot from 3.2.3 to 3.2.6.

The Spring Boot upgrade indirectly upgrades spring-web from 6.1.4 to 6.1.8 fixing UriComponentsBuilder Open Redirect:

* https://spring.io/security/cve-2024-22259
* https://spring.io/security/cve-2024-22262

The Spring Boot upgrade indirectly upgrades netty-codec-http from 4.1.107.Final to 4.1.110.Final fixing form POST OOM:

* https://github.com/netty/netty/security/advisories/GHSA-5jpm-x58v-624v = CVE-2024-29025