### PR TITLE
bump up edge-common-spring to v2.4.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <edge-common-spring.version>2.4.4</edge-common-spring.version>
+    <edge-common-spring.version>2.4.5</edge-common-spring.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <wiremock.version>3.4.2</wiremock.version>
     <awaitility.version>4.2.0</awaitility.version>
@@ -37,16 +37,9 @@
 
     <edge-caiasoft.yaml.file>src/main/resources/swagger.api/edge-caiasoft.yaml</edge-caiasoft.yaml.file>
     <sonar.exclusions>src/main/java/org/folio/ed/domain/**, src/main/java/org/folio/ed/EdgeCaiaSoftApplication.java</sonar.exclusions>
-    <folio-tls-utils.version>1.5.0</folio-tls-utils.version>
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>org.folio</groupId>
-      <artifactId>folio-tls-utils</artifactId>
-      <version>${folio-tls-utils.version}</version>
-    </dependency>
-
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common-spring</artifactId>


### PR DESCRIPTION
bump up edge-common-spring to v2.4.5: AwsParamStore to support FIPS-approved crypto modules
