### PR TITLE
EDGCSOFT-79: Spring Boot 3.2.12 fixing tomcat-embed-core vulns (Quesnelia)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.6</version>
+    <version>3.2.12</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGCSOFT-79

## Purpose
Fix these security vulnerabilities in Quenselia branch b2.2:

* https://www.cve.org/CVERecord?id=CVE-2024-38286 tomcat-embed-core OutOfMemoryError in TLS 1.3
* https://www.cve.org/CVERecord?id=CVE-2024-34750 tomcat-embed-core HTTP/2 stream causing an out-of-memory error or exhausting maxConnections

## Approach
Upgrade Spring Boot from 3.2.6 to 3.2.12.

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [x] There are no breaking changes in this PR.
   - [x] Check logging